### PR TITLE
Add indenting for blocks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ homepage = "https://docs.rs/ruast"
 tokenize = ["dep:proc-macro2", "dep:quote"]
 
 [dependencies]
+indenter = { version = "0.3.3", features = ["std"] }
 proc-macro2 = { version = "1.0", optional = true }
 quote = { version = "1.0", optional = true }
 
@@ -23,4 +24,3 @@ insta = "1.40.0"
 
 [profile.dev.package]
 insta.opt-level = 3
-similar.opt-level = 3

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -666,7 +666,7 @@ impl fmt::Display for If {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "if {cond} {then}", cond = self.cond, then = self.then)?;
         if let Some(else_) = &self.else_ {
-            write!(f, " else {{ {else_} }}", else_ = else_)?;
+            write!(f, " else {else_}")?;
         }
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -236,7 +236,11 @@ impl Crate {
         Ok(())
     }
 
-    pub fn compile(self, rs_path: impl AsRef<Pt>, options: CompileOptions) -> Result<(), std::io::Error> {
+    pub fn compile(
+        self,
+        rs_path: impl AsRef<Pt>,
+        options: CompileOptions,
+    ) -> Result<(), std::io::Error> {
         let rs_path = rs_path.as_ref();
         let mut file = File::create(rs_path)?;
         write!(file, "{}", self)?;

--- a/src/stmt.rs
+++ b/src/stmt.rs
@@ -834,7 +834,11 @@ impl Fn {
         }
     }
 
-    pub fn new_unsafe(ident: impl Into<String>, generics: Vec<GenericParam>, fn_decl: FnDecl) -> Self {
+    pub fn new_unsafe(
+        ident: impl Into<String>,
+        generics: Vec<GenericParam>,
+        fn_decl: FnDecl,
+    ) -> Self {
         Self {
             is_unsafe: true,
             is_const: false,
@@ -847,7 +851,11 @@ impl Fn {
         }
     }
 
-    pub fn new_const(ident: impl Into<String>, generics: Vec<GenericParam>, fn_decl: FnDecl) -> Self {
+    pub fn new_const(
+        ident: impl Into<String>,
+        generics: Vec<GenericParam>,
+        fn_decl: FnDecl,
+    ) -> Self {
         Self {
             is_unsafe: false,
             is_const: true,
@@ -860,7 +868,11 @@ impl Fn {
         }
     }
 
-    pub fn new_async(ident: impl Into<String>, generics: Vec<GenericParam>, fn_decl: FnDecl) -> Self {
+    pub fn new_async(
+        ident: impl Into<String>,
+        generics: Vec<GenericParam>,
+        fn_decl: FnDecl,
+    ) -> Self {
         Self {
             is_unsafe: false,
             is_const: false,
@@ -873,7 +885,11 @@ impl Fn {
         }
     }
 
-    pub fn extern_c(ident: impl Into<String>, generics: Vec<GenericParam>, fn_decl: FnDecl) -> Self {
+    pub fn extern_c(
+        ident: impl Into<String>,
+        generics: Vec<GenericParam>,
+        fn_decl: FnDecl,
+    ) -> Self {
         Self {
             is_unsafe: false,
             is_const: false,
@@ -1913,7 +1929,12 @@ impl HasItem<AssocItem> for TraitDef {
 impl_hasitem_methods!(TraitDef, AssocItem);
 
 impl TraitDef {
-    pub fn new(ident: impl Into<String>, generics: Vec<GenericArg>, supertraits: Vec<Type>, items: Vec<AssocItem>) -> Self {
+    pub fn new(
+        ident: impl Into<String>,
+        generics: Vec<GenericArg>,
+        supertraits: Vec<Type>,
+        items: Vec<AssocItem>,
+    ) -> Self {
         Self {
             ident: ident.into(),
             generics,
@@ -2148,7 +2169,7 @@ impl Impl {
         of_trait: Option<Type>,
         self_ty: Type,
         where_clauses: Option<Vec<WherePredicate>>,
-        items: Vec<AssocItem>
+        items: Vec<AssocItem>,
     ) -> Self {
         Self {
             generics,

--- a/src/stmt.rs
+++ b/src/stmt.rs
@@ -1,3 +1,4 @@
+use core::fmt::Write;
 use std::fmt;
 use std::hash::Hash;
 
@@ -1110,11 +1111,17 @@ impl fmt::Display for Block {
         if let Some(label) = &self.label {
             write!(f, "'{label}: ")?;
         }
-        writeln!(f, "{{")?;
-        for stmt in self.stmts.iter() {
-            writeln!(f, "{stmt}")?;
+        if self.stmts.is_empty() {
+            write!(f, "{{}}")?;
+        } else {
+            writeln!(f, "{{")?;
+            let mut indent = indenter::indented(f).with_str("    ");
+            for stmt in self.stmts.iter() {
+                writeln!(indent, "{stmt}")?;
+            }
+            write!(f, "}}")?;
         }
-        write!(f, "}}")
+        Ok(())
     }
 }
 

--- a/src/ty.rs
+++ b/src/ty.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use crate::expr::{Const, Path, PathSegment, GenericArg};
+use crate::expr::{Const, GenericArg, Path, PathSegment};
 use crate::stmt::Param;
 use crate::token::{BinOpToken, Delimiter, KeywordToken, Token, TokenStream};
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,5 +1,5 @@
-use ruast::*;
 use insta::assert_snapshot;
+use ruast::*;
 
 #[test]
 fn test() -> Result<(), ()> {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -2,7 +2,7 @@ use insta::assert_snapshot;
 use ruast::*;
 
 #[test]
-fn test() -> Result<(), ()> {
+fn test() {
     let mut krate = Crate::new();
     let def = Fn::main(
         None,
@@ -14,17 +14,16 @@ fn test() -> Result<(), ()> {
     krate.add_item(def);
     assert_snapshot!(krate, @r###"
     fn main() {
-    println!("Hello, world!")
+        println!("Hello, world!")
     }
     "###);
     krate.remove_item_by_id("main");
     assert!(krate.is_empty());
     assert_snapshot!(krate, @"");
-    Ok(())
 }
 
 #[test]
-fn test_general() -> Result<(), ()> {
+fn test_general() {
     let mut krate = Crate::new();
     krate.add_item(Fn {
         is_unsafe: false,
@@ -41,13 +40,21 @@ fn test_general() -> Result<(), ()> {
     });
     assert_snapshot!(krate, @r###"
     fn main() {
-    println!("Hello, world!")
+        println!("Hello, world!")
     }
     "###);
     assert_snapshot!(krate[0], @r###"
     fn main() {
-    println!("Hello, world!")
+        println!("Hello, world!")
     }
     "###);
-    Ok(())
+}
+
+#[test]
+fn test_blocks() {
+    let block = Block::from(Stmt::Expr(Expr::new(Lit::int("17"))));
+    assert_snapshot!(block, @"
+    {
+        17
+    }");
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -57,4 +57,36 @@ fn test_blocks() {
     {
         17
     }");
+
+    assert_snapshot!(Block::empty(), @"{}");
+}
+
+#[test]
+fn test_if_else() {
+    let if_else = If::new(
+        Expr::new(Lit::bool("true")),
+        Block::from(Stmt::Expr(Expr::new(Lit::int("17")))),
+        Some(Expr::from(Block::from(Stmt::Expr(Expr::new(Lit::int(
+            "39",
+        )))))),
+    );
+    assert_snapshot!(if_else, @"
+    if true {
+        17
+    } else {
+        39
+    }");
+    let if_elseif_else = If::new(
+        Expr::new(Lit::bool("false")),
+        Block::from(Stmt::Expr(Expr::new(Lit::int("1")))),
+        Some(Expr::from(if_else)),
+    );
+    assert_snapshot!(if_elseif_else, @"
+    if false {
+        1
+    } else if true {
+        17
+    } else {
+        39
+    }");
 }


### PR DESCRIPTION
- depends on https://github.com/mtshiba/ruast/pull/2
- add a dependency on the `indenter` crate
- switch from `If(Expr, Block, Option(Expr))` to `If(Expr, Block, Option(Block))` so that Block handles all the braces.
