### PR TITLE
Added support for raw pointers next to references

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1838,6 +1838,15 @@ impl Mutability {
     }
 }
 
+impl fmt::Display for Mutability {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Mutability::Mut => write!(f, "mut"),
+            Mutability::Not => write!(f, "const"),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct AddrOf {
     pub kind: BorrowKind,

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1842,7 +1842,7 @@ impl fmt::Display for Mutability {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Mutability::Mut => write!(f, "mut"),
-            Mutability::Not => write!(f, "const"),
+            Mutability::Not => write!(f, ""),
         }
     }
 }

--- a/src/ty.rs
+++ b/src/ty.rs
@@ -144,7 +144,7 @@ impl From<Ptr> for TokenStream {
 impl Ptr {
     pub fn new(kind: PtrKind, ty: impl Into<Type>) -> Self {
         Self {
-            kind: kind,
+            kind,
             ty: Box::new(ty.into()),
         }
     }

--- a/src/ty.rs
+++ b/src/ty.rs
@@ -7,6 +7,7 @@ use crate::token::{BinOpToken, Delimiter, KeywordToken, Token, TokenStream};
 #[cfg(feature = "tokenize")]
 crate::impl_to_tokens!(
     MutTy,
+    Ptr,
     Ref,
     BareFn,
     PolyTraitRef,
@@ -88,6 +89,63 @@ impl Ref {
         Self {
             lifetime: lifetime.map(|l| l.into()),
             ty,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum PtrKind {
+    Const,
+    Mut,
+}
+
+impl fmt::Display for PtrKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            PtrKind::Const => write!(f, "const"),
+            PtrKind::Mut => write!(f, "mut"),
+        }
+    }
+}
+
+impl From<PtrKind> for TokenStream {
+    fn from(value: PtrKind) -> Self {
+        let mut ts = TokenStream::new();
+        ts.push(match value {
+            PtrKind::Mut => Token::Keyword(KeywordToken::Mut),
+            PtrKind::Const => Token::Keyword(KeywordToken::Const),
+        });
+        ts
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Ptr {
+    pub ty: Box<Type>,
+    pub kind: PtrKind,
+}
+
+impl fmt::Display for Ptr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "*{} {}", self.kind, self.ty)
+    }
+}
+
+impl From<Ptr> for TokenStream {
+    fn from(value: Ptr) -> Self {
+        let mut ts = TokenStream::new();
+        ts.push(Token::BinOp(BinOpToken::Star));
+        ts.extend(TokenStream::from(value.kind));
+        ts.extend(TokenStream::from(*value.ty));
+        ts
+    }
+}
+
+impl Ptr {
+    pub fn new(kind: PtrKind, ty: impl Into<Type>) -> Self {
+        Self {
+            kind: kind,
+            ty: Box::new(ty.into()),
         }
     }
 }
@@ -339,6 +397,7 @@ impl ImplTrait {
 pub enum Type {
     Slice(Box<Type>),
     Array(Box<Type>, Box<Const>),
+    Ptr(Ptr),
     Ref(Ref),
     BareFn(BareFn),
     Never,
@@ -357,6 +416,7 @@ impl fmt::Display for Type {
             Self::Slice(ty) => write!(f, "[{ty}]"),
             Self::Array(ty, len) => write!(f, "[{ty}; {len}]"),
             Self::Ref(r) => write!(f, "{r}"),
+            Self::Ptr(p) => write!(f, "{p}"),
             Self::BareFn(bare_fn) => write!(f, "{bare_fn}"),
             Self::Never => write!(f, "!"),
             Self::Tuple(tys) => write!(
@@ -402,6 +462,7 @@ impl From<Type> for TokenStream {
                 ts.push(Token::CloseDelim(Delimiter::Bracket));
                 ts
             }
+            Type::Ptr(ptr) => TokenStream::from(ptr),
             Type::Ref(ref_) => TokenStream::from(ref_),
             Type::BareFn(bare_fn) => TokenStream::from(bare_fn),
             Type::Never => TokenStream::from(vec![Token::Not]),
@@ -442,5 +503,13 @@ impl Type {
 
     pub fn poly_path(ident: impl Into<String>, args: Vec<GenericArg>) -> Type {
         Type::Path(Path::single(PathSegment::new(ident, Some(args))))
+    }
+
+    pub fn const_ptr(ty: impl Into<Type>) -> Type {
+        Type::Ptr(Ptr::new(PtrKind::Const, ty))
+    }
+
+    pub fn mut_ptr(ty: impl Into<Type>) -> Type {
+        Type::Ptr(Ptr::new(PtrKind::Mut, ty))
     }
 }


### PR DESCRIPTION
I am very new to this project but it seemed like it lacked support for raw pointer types which is something I needed for my usecase. To add it, I just added another variant to the Type enum.

One part I am not quite sure about is the Display implementation of the Mutability enum. I made it so that `Mutability::Not` prints "const" and `Mutability::Mut` prints "mut". It is not a breaking change since the display trait was not yet implemented, but it might be that `Mutability::Not` should actually render to "". 

Please let me know your thoughts on this, thanks!