### PR TITLE
Mark Semi expression field public

### DIFF
--- a/src/stmt.rs
+++ b/src/stmt.rs
@@ -2619,7 +2619,7 @@ impl From<Empty> for TokenStream {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct Semi(Expr);
+pub struct Semi(pub Expr);
 
 impl fmt::Display for Semi {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {


### PR DESCRIPTION
Marking the `Semi()` expression field public allows pattern matching on the struct.
This is also in line with all other structs which have public fields.