### PR TITLE
Some expressions did not generate TokenStream parenthesis

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -655,9 +655,11 @@ impl fmt::Display for Binary {
 impl From<Binary> for TokenStream {
     fn from(value: Binary) -> Self {
         let mut ts = TokenStream::new();
+        ts.push(Token::OpenDelim(Delimiter::Parenthesis));
         ts.extend(TokenStream::from(*value.lhs));
         ts.push(Token::from(value.op));
         ts.extend(TokenStream::from(*value.rhs));
+        ts.push(Token::CloseDelim(Delimiter::Parenthesis));
         ts
     }
 }

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -745,8 +745,10 @@ impl fmt::Display for Unary {
 impl From<Unary> for TokenStream {
     fn from(value: Unary) -> Self {
         let mut ts = TokenStream::new();
+        ts.push(Token::OpenDelim(Delimiter::Parenthesis));
         ts.push(Token::from(value.op));
         ts.extend(TokenStream::from(*value.expr));
+        ts.push(Token::CloseDelim(Delimiter::Parenthesis));
         ts
     }
 }


### PR DESCRIPTION
Binary and unary operations are wrapped with parenthesis when displaying them, but these same parenthesis were not generated when converted to token streams.