### PR TITLE
Variadic functions

### DIFF
--- a/examples/struct.rs
+++ b/examples/struct.rs
@@ -6,7 +6,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_field(FieldDef::inherited("foo", Type::from("u32")))
         .with_field(FieldDef::inherited("bar", Type::from("u32")));
     krate.add_item(def);
-    let fn_decl = FnDecl::new(vec![Param::ref_self(), Param::ident("x", Type::usize())], Some(Type::usize()));
+    let fn_decl = FnDecl::regular(vec![Param::ref_self(), Param::ident("x", Type::usize())], Some(Type::usize()));
     let add = Lit::int("1").bin_op(BinOpKind::Add, Path::single("x"));
     let body = Block::new(vec![Stmt::Expr(add.into())], None);
     let f = Fn::simple("foo", fn_decl, body);

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -33,7 +33,7 @@ fn test_general() {
         abi: None,
         ident: "main".to_string(),
         generics: vec![],
-        fn_decl: FnDecl::new(vec![], None),
+        fn_decl: FnDecl::regular(vec![], None),
         body: Some(Block::from(Stmt::Semi(Semi::new(Expr::new(MacCall {
             path: Path::single("println"),
             args: DelimArgs::from(vec![Token::lit("Hello, world!")]),


### PR DESCRIPTION
Ruast currently does not support variadic functions. I have added an `is_variadic` flag to `FnDecl`. I know this is not ideal since `FnDecl` is reused by other function like types such as closures which cannot be variadic. But if you add the flag to the regular `Fn` you also have to copy all code for the display and tokenize traits. 
So I opted for this approach, let me know if you want it implemented a different way. 

For reference:
[rust fn reference](https://doc.rust-lang.org/reference/types/function-pointer.html)
Syn also implement a `variadic` flag in their `Signature` [reference](https://docs.rs/syn/latest/syn/struct.Signature.html)