### PR TITLE
Generic argument use incorrect brackets for tokenstreams

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -2081,14 +2081,15 @@ impl From<PathSegment> for TokenStream {
         let mut ts = TokenStream::new();
         ts.push(Token::ident(value.ident));
         if let Some(args) = value.args {
-            ts.push(Token::OpenDelim(Delimiter::Bracket));
+            ts.push(Token::ModSep);
+            ts.push(Token::Lt);
             for (i, arg) in args.iter().enumerate() {
                 if i > 0 {
                     ts.push(Token::Comma);
                 }
                 ts.extend(TokenStream::from(arg.clone()));
             }
-            ts.push(Token::CloseDelim(Delimiter::Bracket));
+            ts.push(Token::Gt);
         }
         ts
     }


### PR DESCRIPTION
The generic arguments in a `Path` generate square brackets `[]` instead of angle brackets `<>` in their tokenstream. Additionally the `ModSep` token is also not inserted before handling generic arguments. This PR fixes both of these issues. 

The code previously used the `Delimiter` tokens but these do not contain the `<` `>` tokens. I wanted to add them to the delimiters but `proc_macro2` does not include them in their delimiter enum either and I think the delimiter enum was largely based on theirs. If the `<` and `>` tokens get added as delimiters you cannot easily convert to the `proc_macro2` delimiters. See `token.rs:159`