### PR TITLE
fix: wrapping AddrOf with parenthesis get rid of precedence issues

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -2164,7 +2164,7 @@ pub struct AddrOf {
 
 impl fmt::Display for AddrOf {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "&")?;
+        write!(f, "(&")?;
         match (self.kind, self.mutability) {
             (BorrowKind::Ref, Mutability::Not) => {}
             (BorrowKind::Ref, Mutability::Mut) => {
@@ -2177,13 +2177,14 @@ impl fmt::Display for AddrOf {
                 write!(f, "raw mut ")?;
             }
         }
-        write!(f, "{expr}", expr = self.expr)
+        write!(f, "{expr})", expr = self.expr)
     }
 }
 
 impl From<AddrOf> for TokenStream {
     fn from(value: AddrOf) -> Self {
         let mut ts = TokenStream::new();
+        ts.push(Token::OpenDelim(Delimiter::Parenthesis));
         ts.push(Token::And);
         match (value.kind, value.mutability) {
             (BorrowKind::Ref, Mutability::Not) => {}
@@ -2200,6 +2201,7 @@ impl From<AddrOf> for TokenStream {
             }
         }
         ts.extend(TokenStream::from(*value.expr));
+        ts.push(Token::CloseDelim(Delimiter::Parenthesis));
         ts
     }
 }


### PR DESCRIPTION
In some cases, address of creates precedence issues.
For example in the following example, there is a difference between `foo(&x + 1)` and `foo(&(x + 1))`, but the ruast AST for both of these would generate `foo(&x+1)`

Wrapping `AddrOf` with parenthesis fixes this issue.

```rust
fn foo(x: &i32) {
}

fn main() {
    let x = 123;

    foo(&(x + 1));
}
```