### PR TITLE
fix: allow multiple shebangs

### DIFF
--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -149,6 +149,7 @@ impl ToTokens for Token {
                 &keyword.to_string(),
                 Span::call_site(),
             ))]),
+            Self::Shebang(_) => {}
             Self::DocComment(_) => {}
             Self::Eof => {}
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,7 +156,7 @@ pub(crate) use impl_hasitem_methods;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
 pub struct Crate {
-    pub shebang: Option<String>,
+    pub shebangs: Vec<String>,
     pub attrs: Vec<Attribute>,
     pub items: Vec<Item>,
 }
@@ -181,6 +181,9 @@ impl_hasitem_methods!(Crate);
 
 impl fmt::Display for Crate {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for shebang in &self.shebangs {
+            writeln!(f, "#!{shebang}")?;
+        }
         for attr in self.attrs.iter() {
             writeln!(f, "{attr}")?;
         }
@@ -195,6 +198,11 @@ impl fmt::Display for Crate {
 impl From<Crate> for TokenStream {
     fn from(value: Crate) -> Self {
         let mut ts = TokenStream::new();
+        for shebang in value.shebangs {
+            ts.push(Token::Pound);
+            ts.push(Token::Not);
+            ts.push(Token::Shebang(shebang));
+        }
         for attr in value.attrs {
             ts.extend(TokenStream::from(attr));
         }
@@ -232,7 +240,7 @@ pub struct CompileOptions {
 impl Crate {
     pub fn new() -> Self {
         Self {
-            shebang: None,
+            shebangs: vec![],
             attrs: Vec::new(),
             items: Vec::new(),
         }

--- a/src/token.rs
+++ b/src/token.rs
@@ -253,6 +253,7 @@ pub enum Token {
     Lifetime(String),
     Keyword(KeywordToken),
     DocComment(String),
+    Shebang(String),
     Eof,
 }
 
@@ -295,6 +296,7 @@ impl fmt::Display for Token {
             Self::Lifetime(lifetime) => write!(f, "'{lifetime}"),
             Self::Keyword(keyword) => write!(f, "{keyword}"),
             Self::DocComment(comment) => write!(f, "{comment}"),
+            Self::Shebang(shebang) => write!(f, "{shebang}"),
             Self::Eof => write!(f, ""),
         }
     }


### PR DESCRIPTION
This PR allows multiple shebangs to exist in a crate.
This way you can allow multiple things for example:
```rust
#![allow(dead_code)]
#![feature(array_try_map)]
```

Additionally, it also prints the shebangs to the output stream and token stream.