### PR TITLE
fix: const and async specifier should go ahead of unsafe specifier

### DIFF
--- a/src/stmt.rs
+++ b/src/stmt.rs
@@ -749,14 +749,14 @@ pub struct Fn {
 
 impl fmt::Display for Fn {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if self.is_unsafe {
-            write!(f, "unsafe ")?;
-        }
         if self.is_const {
             write!(f, "const ")?;
         }
         if self.is_async {
             write!(f, "async ")?;
+        }
+        if self.is_unsafe {
+            write!(f, "unsafe ")?;
         }
         if let Some(abi) = &self.abi {
             write!(f, "extern \"{abi}\" ")?;
@@ -786,14 +786,14 @@ impl fmt::Display for Fn {
 impl From<Fn> for TokenStream {
     fn from(value: Fn) -> Self {
         let mut ts = TokenStream::new();
-        if value.is_unsafe {
-            ts.push(Token::Keyword(KeywordToken::Unsafe));
-        }
         if value.is_const {
             ts.push(Token::Keyword(KeywordToken::Const));
         }
         if value.is_async {
             ts.push(Token::Keyword(KeywordToken::Async));
+        }
+        if value.is_unsafe {
+            ts.push(Token::Keyword(KeywordToken::Unsafe));
         }
         if let Some(abi) = value.abi {
             ts.push(Token::Keyword(KeywordToken::Extern));


### PR DESCRIPTION
The `const` and `async` function specifiers should come ahead of the safety specifier.
This PR just reorders the unsafe display and tokenize order.

[Reference](https://doc.rust-lang.org/reference/items/functions.html)