### PR TITLE
feat: add Scoped variant to Visibility

### DIFF
--- a/src/stmt.rs
+++ b/src/stmt.rs
@@ -2491,6 +2491,7 @@ pub enum Visibility {
     #[default]
     Inherited,
     Public,
+    Scoped(Path),
 }
 
 impl fmt::Display for Visibility {
@@ -2498,6 +2499,7 @@ impl fmt::Display for Visibility {
         match self {
             Self::Inherited => write!(f, ""),
             Self::Public => write!(f, "pub "),
+            Self::Scoped(path) => write!(f, "pub({}) ", path),
         }
     }
 }
@@ -2507,6 +2509,14 @@ impl From<Visibility> for TokenStream {
         match value {
             Visibility::Inherited => TokenStream::new(),
             Visibility::Public => TokenStream::from(vec![Token::Keyword(KeywordToken::Pub)]),
+            Visibility::Scoped(path) => {
+                let mut ts = TokenStream::new();
+                ts.push(Token::Keyword(KeywordToken::Pub));
+                ts.push(Token::OpenDelim(Delimiter::Parenthesis));
+                ts.extend(TokenStream::from(path));
+                ts.push(Token::CloseDelim(Delimiter::Parenthesis));
+                ts
+            }
         }
     }
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -200,3 +200,29 @@ fn test_match() {
     _ => 0,
 }");
 }
+
+#[test]
+fn test_visibility_scope() {
+    let vis_crate = Visibility::crate_();
+    assert_snapshot!(vis_crate, @"pub(crate) ");
+
+    let vis_super = Visibility::super_();
+    assert_snapshot!(vis_super, @"pub(super) ");
+
+    let vis_self = Visibility::self_();
+    assert_snapshot!(vis_self, @"pub(self) ");
+
+    let path = Path::single("my_module");
+    let vis_path = Visibility::in_path(path);
+    assert_snapshot!(vis_path, @"pub(in my_module) ");
+
+    let nested_path = Path::single("crate").chain("module").chain("submodule");
+    let vis_nested_path = Visibility::in_path(nested_path);
+    assert_snapshot!(vis_nested_path, @"pub(in crate::module::submodule) ");
+
+    let vis_inherited = Visibility::default();
+    assert_snapshot!(vis_inherited, @"");
+
+    let vis_public = Visibility::Public;
+    assert_snapshot!(vis_public, @"pub ");
+}


### PR DESCRIPTION
Added `Scoped(Path)` to `Visibility` to generate ast for like `pub(crate)`
https://doc.rust-lang.org/reference/visibility-and-privacy.html#r-vis.scoped

Tested here.
https://github.com/estie-inc/wasm-xlsxwriter/pull/127