### PR TITLE
feat: support for patterned variadic

### DIFF
--- a/src/stmt.rs
+++ b/src/stmt.rs
@@ -846,6 +846,9 @@ impl fmt::Display for FnDecl {
             }
             write!(f, "{param}")?;
         }
+        if self.inputs.len() > 0 && self.is_variadic() {
+            write!(f, ", ")?;
+        }
         write!(f, "{param_count}", param_count = self.param_count)?;
         write!(f, ")")?;
         if let Some(output) = &self.output {
@@ -865,6 +868,9 @@ impl From<FnDecl> for TokenStream {
             }
             ts.extend(TokenStream::from(param.clone()).into_joint());
         }
+        if value.inputs.len() > 0 && value.is_variadic() {
+            ts.push(Token::Comma);
+        } 
         ts.extend(TokenStream::from(value.param_count));
         ts.push(Token::CloseDelim(Delimiter::Parenthesis));
         if let Some(output) = value.output {
@@ -913,6 +919,10 @@ impl FnDecl {
     pub fn with_output(mut self, output: Type) -> Self {
         self.set_output(output);
         self
+    }
+
+    pub fn is_variadic(&self) -> bool {
+        matches!(self.param_count, ParamCount::Variadic(_))
     }
 }
 

--- a/tests/test_tokenstream.rs
+++ b/tests/test_tokenstream.rs
@@ -983,7 +983,7 @@ fn test_fndecl_to_tokenstream() {
     let fn_decl = FnDecl::new(
         vec![Param::new(Pat::ident("x"), Type::i32())],
         Some(Type::unit()),
-        false,
+        ParamCount::Fixed,
     );
     let ts = TokenStream::from(fn_decl);
     assert_snapshot!(ts, @"(x: i32) -> ()");
@@ -993,7 +993,7 @@ fn test_fndecl_to_tokenstream() {
 fn test_fn_to_tokenstream() {
     let fn_item = Fn::simple(
         "test_func",
-        FnDecl::new(vec![], Some(Type::unit()), false),
+        FnDecl::new(vec![], Some(Type::unit()), ParamCount::Fixed),
         Block::empty(),
     );
     let ts = TokenStream::from(fn_item);


### PR DESCRIPTION
This PR extends `FnDecl` with a `param_count` field to denote whether this function declaration has a fixed or variable number of arguments. 
Patterns may or may not provided, as they can be in Rust.

This allows function declarations such as 
`(x: u32, ...)` as well as `(x: u32, y: ...)` to be represented.