### PR TITLE
fix: left shift parenthesis edge case

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -881,7 +881,7 @@ impl fmt::Display for Binary {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.precedence() < self.lhs.precedence()
         // foo as T < y ==> (foo as T) < y
-        || (self.op == BinOpKind::Lt && self.lhs.precedence() == OperatorPrecedence::Cast)
+        || ((self.op == BinOpKind::Lt || self.op == BinOpKind::Shl) && self.lhs.precedence() == OperatorPrecedence::Cast)
         {
             write!(f, "({})", self.lhs)?;
         } else {
@@ -903,7 +903,7 @@ impl From<Binary> for TokenStream {
         let precedence = value.precedence();
         if precedence < value.lhs.precedence()
         // foo as T < y ==> (foo as T) < y
-        || (value.op == BinOpKind::Lt && value.lhs.precedence() == OperatorPrecedence::Cast)
+        || ((value.op == BinOpKind::Lt || value.op == BinOpKind::Shl) && value.lhs.precedence() == OperatorPrecedence::Cast)
         {
             ts.push(Token::OpenDelim(Delimiter::Parenthesis).into_joint());
             ts.extend(TokenStream::from(*value.lhs).into_joint());


### PR DESCRIPTION
When performing a left shift with a cast in the left hand side expression, the rust parser requires parenthesis around the cast operation.
This is also the case for the less-than operator for which this edge-case was already caught.
This PR simply extends on that solution by adding an additional left-shift check.